### PR TITLE
fix(ci): add explicit workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     name: Build on Node.js ${{ matrix.node-version }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Fixes GitHub CodeQL security alert #1 by adding explicit GITHUB_TOKEN permissions to the CI workflow.

## Changes

- Added `permissions: contents: read` to the build job in `.github/workflows/ci.yml`
- Uses minimal required permissions following the principle of least privilege
- The build job only needs read access to checkout code and run builds

## Security Impact

- Resolves medium-severity code scanning alert about missing workflow permissions
- Prevents potential privilege escalation by explicitly restricting GITHUB_TOKEN scope
- Aligns with GitHub security best practices for Actions workflows

Fixes code scanning alert #1