### PR TITLE
fix(ci): replace manual apt caching with specialized action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libftdi-dev libftdi1
+      - name: Cache apt packages
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libftdi-dev libftdi1
+          version: 1.0
 
       - name: Install dependencies and build
         run: npm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache apt packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: libftdi-dev libftdi1
           version: 1.0

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Cache apt packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: libftdi-dev libftdi1
           version: 1.0

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -23,19 +23,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Cache apt packages
-        uses: actions/cache@v4
+        uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          path: |
-            /var/cache/apt/archives
-            /var/lib/apt/lists
-          key: ${{ runner.os }}-apt-${{ hashFiles('.github/workflows/pkg-pr-new.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-apt-
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libftdi-dev libftdi1
+          packages: libftdi-dev libftdi1
+          version: 1.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Fixes permission denied errors in GitHub Actions workflows when caching apt packages.

## Problem

The workflows were experiencing errors during post-job cleanup:
```
/usr/bin/tar: ../../../../../var/cache/apt/archives/lock: Permission denied
/usr/bin/tar: ../../../../../var/cache/apt/archives/partial: Permission denied
```

This occurred because `actions/cache` was trying to cache system directories (`/var/cache/apt/archives` and `/var/lib/apt/lists`) that contain root-owned lock files inaccessible to the runner user.

## Solution

Replaced `actions/cache` with [`awalsh128/cache-apt-pkgs-action@latest`](https://github.com/awalsh128/cache-apt-pkgs-action), a specialized action that:
- Caches packages to user-owned directories (`~/cache-apt-pkgs`)
- Handles `sudo apt-get update` and `install` internally
- Avoids permission issues by not accessing system lock files
- Simplifies workflow configuration

## Changes

- **`.github/workflows/pkg-pr-new.yml`**: Replaced manual apt caching with specialized action
- **`.github/workflows/ci.yml`**: Added apt package caching for consistency and performance

## Testing

The workflows will be tested automatically when this PR is created. The cache action should:
1. Successfully cache libftdi packages on first run
2. Restore from cache on subsequent runs
3. Complete without permission errors

## References

- [GitHub Community Discussion #26239](https://github.com/orgs/community/discussions/26239)
- [actions/toolkit Issue #946](https://github.com/actions/toolkit/issues/946) - No official sudo support for actions/cache
- [cache-apt-pkgs-action documentation](https://github.com/awalsh128/cache-apt-pkgs-action#readme)