### PR TITLE
feat(ci): add dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
## Summary

- Adds `github-actions` package ecosystem to dependabot configuration
- Enables automatic dependency updates for GitHub Actions workflows
- Uses monthly update schedule to match existing npm configuration

## Test plan

- [x] Configuration file syntax is valid
- [ ] Verify dependabot creates PRs for action updates after merge