### PR TITLE
Add reference to node-dmx/dmx as alternative library

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,29 @@ Description
 
 Control any DMX512 compatible lighting system with node.js via FTDI USB-RS485 cable.
 
+This is a native C++ addon using libftdi for direct hardware control, providing low-latency DMX transmission with generic FTDI-based USB-RS485 converters (such as FT232RL + SP485 chipsets).
+
+Alternatives
+------
+
+If you need support for multiple DMX controller types beyond FTDI USB-RS485 cables, consider [node-dmx/dmx](https://github.com/node-dmx/dmx), a JavaScript library with pluggable drivers for:
+
+- Enttec USB DMX Pro (recommended by that project)
+- DMXKing ultraDMX devices
+- Art-Net protocol
+- BeagleBone-DMX
+- Various other controllers
+
+**Choose this project (groupsky/node-dmx) if you:**
+- Use generic FTDI USB-RS485 cables (like the [cheap AliExpress adapters](https://s.click.aliexpress.com/e/_c3lqFhuX) with FT232RL + SP485 chipsets)
+- Need direct hardware control with minimal latency
+- Want a lightweight, focused solution without abstraction layers
+
+**Choose node-dmx/dmx if you:**
+- Need to support multiple different DMX controller types
+- Want built-in animation features and multi-universe management
+- Prefer pure JavaScript without native compilation
+
 Requirements
 ------
 * node.js


### PR DESCRIPTION
## Summary

Adds a comprehensive "Alternatives" section to the README that references the [node-dmx/dmx](https://github.com/node-dmx/dmx) JavaScript library for users who need multi-controller support beyond FTDI USB-RS485 cables.

**Key additions:**
- Clarify this project is a native C++ addon targeting generic FTDI USB-RS485 cables (FT232RL + SP485 chipsets)
- Reference node-dmx/dmx library and list its supported controller types (Enttec Pro, DMXKing, Art-Net, BeagleBone-DMX, etc.)
- Provide clear decision criteria to help users choose between projects based on their hardware and requirements
- Confirm compatibility with cheap AliExpress USB-RS485 DMX adapters

**Research conducted:**
- Analyzed C++ source code to understand FTDI chipset support (0x0403:0x6001)
- Researched node-dmx/dmx project capabilities and driver ecosystem
- Verified FT232RL + SP485 chipset compatibility

This helps users make informed decisions about which library best fits their use case without needing to discover alternatives through trial and error.

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Check all links are working (node-dmx/dmx, AliExpress adapter)
- [ ] Ensure formatting is consistent with existing README style