### PR TITLE
Add status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 [![GitHub release](https://img.shields.io/github/v/release/groupsky/node-dmx)](https://github.com/groupsky/node-dmx/releases)
 [![CI](https://img.shields.io/github/actions/workflow/status/groupsky/node-dmx/ci.yml?branch=main)](https://github.com/groupsky/node-dmx/actions/workflows/ci.yml)
 [![Node version](https://img.shields.io/badge/node-%3E%3D16.0.0-brightgreen)](https://nodejs.org/)
-[![License](https://img.shields.io/github/license/groupsky/node-dmx)](https://github.com/groupsky/node-dmx/blob/main/LICENSE)
-[![Platform](https://img.shields.io/badge/platform-linux-lightgrey)](https://github.com/groupsky/node-dmx#requirements)
 ![Native addon](https://img.shields.io/badge/native-addon-blue)
 [![pkg.pr.new](https://pkg.pr.new/badge/groupsky/node-dmx)](https://pkg.pr.new/~/groupsky/node-dmx)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+[![GitHub release](https://img.shields.io/github/v/release/groupsky/node-dmx)](https://github.com/groupsky/node-dmx/releases)
+[![CI](https://img.shields.io/github/actions/workflow/status/groupsky/node-dmx/ci.yml?branch=main)](https://github.com/groupsky/node-dmx/actions/workflows/ci.yml)
+[![Node version](https://img.shields.io/badge/node-%3E%3D16.0.0-brightgreen)](https://nodejs.org/)
+[![License](https://img.shields.io/github/license/groupsky/node-dmx)](https://github.com/groupsky/node-dmx/blob/main/LICENSE)
+[![Platform](https://img.shields.io/badge/platform-linux-lightgrey)](https://github.com/groupsky/node-dmx#requirements)
+![Native addon](https://img.shields.io/badge/native-addon-blue)
 [![pkg.pr.new](https://pkg.pr.new/badge/groupsky/node-dmx)](https://pkg.pr.new/~/groupsky/node-dmx)
 
 Description


### PR DESCRIPTION
## Summary

Adds GitHub-based status badges to the README to improve project discoverability and provide quick status overview:

- **GitHub Release**: Shows latest release version
- **CI Status**: Displays build status across Node.js versions (16, 18, 20, 22, 24)
- **Node Version Support**: Indicates minimum Node.js version (>= 16.0.0)
- **Native Addon**: Signals that this requires compilation

Badges are GitHub-based rather than npm-based since this project is not published to npm registry.

Badge ordering provides logical visual hierarchy: status badges first, then technical requirements, then preview releases.

## Test plan

- [ ] Verify badges render correctly in GitHub README
- [ ] Check that all badge links work
- [ ] Confirm CI status badge shows current workflow status