### PR TITLE
fix(ci): add release-please bootstrap config to fix version downgrade

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,8 @@
+{
+  "bootstrap-sha": "6ccbdba9fc7f0d58d8033d65dd79060d9ab5cb23",
+  "packages": {
+    ".": {
+      "release-type": "node"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the release-please version downgrade issue where PR #13 was trying to release v1.0.0 instead of properly bumping from v1.0.2.

## Problem

Release-please couldn't find the existing v1.0.2 release (created Dec 2022, commit `6ccbdba`) in the commit history because:
- The release was created before release-please was added to the project
- Without bootstrap configuration, release-please started from scratch and proposed v1.0.0
- Workflow logs showed: "Unable to find expected version for path '.' in manifest" and "SHA not found in recent commits"

## Solution

Added `release-please-config.json` with `bootstrap-sha` pointing to the v1.0.2 commit. This tells release-please:
- Start analyzing commits from v1.0.2 forward
- Properly calculate the next version based on conventional commits since v1.0.2
- Should now generate v1.1.0 or higher (12 commits include `feat:` changes)

## Next Steps

After merging this PR:
1. Close PR #13 without merging (incorrect version)
2. Wait for release-please to generate a new PR with the correct version bump
3. The `bootstrap-sha` config will be ignored after the first successful release and can be removed in a future cleanup

## References

- Research shows this is the recommended approach for bootstrapping release-please on existing projects
- [Release-Please Manifest Releaser docs](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md)