### PR TITLE
fix(ci): use manifest mode for release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          release-type: node
 
       - name: Release summary
         if: steps.release.outputs.release_created


### PR DESCRIPTION
## Summary

Fixes the release-please workflow to use manifest mode instead of simple mode by removing the inline `release-type` parameter. This allows the workflow to read from `release-please-config.json` and use the `bootstrap-sha` configuration.

## Problem

PR #17 added `release-please-config.json` with `bootstrap-sha`, but the workflow was still trying to downgrade from v1.0.2 to v1.0.0 because:
- The workflow specified `release-type: node` inline
- When `release-type` is specified, the action uses **simple mode**
- Simple mode **ignores** `release-please-config.json` and `bootstrap-sha`
- The workflow logs showed: `✔ updating from 1.0.2 to 1.0.0`

## Solution

Remove `release-type: node` from the workflow to enable **manifest mode**, which:
- Reads configuration from `release-please-config.json`
- Uses the `bootstrap-sha` to start from v1.0.2
- Properly calculates version bumps based on conventional commits

## Expected Result

After merging this PR:
1. Close PR #13 (the incorrect v1.0.0 release)
2. The release workflow will run on merge to main
3. A new PR should be created with v1.1.0 or higher (based on the `feat:` commits since v1.0.2)

## References

- [Release-Please Action Documentation](https://github.com/googleapis/release-please-action#manifest-mode-vs-simple-mode)
- Manifest mode requires `release-please-config.json` and `.release-please-manifest.json`
- Simple mode uses inline parameters and ignores config files