### PR TITLE
feat(deps): configure dependabot to use conventional commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,24 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    commit-message:
+      prefix: "deps(npm)"
+      prefix-development: "chore(npm)"
+    open-pull-requests-limit: 10
+    groups:
+      # Group major updates separately for easier review
+      major-dependencies:
+        update-types:
+          - "major"
+      # Group minor/patch updates together
+      minor-patch-dependencies:
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    commit-message:
+      prefix: "chore(actions)"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,13 @@
   "bootstrap-sha": "6ccbdba9fc7f0d58d8033d65dd79060d9ab5cb23",
   "packages": {
     ".": {
-      "release-type": "node"
+      "release-type": "node",
+      "changelog-sections": [
+        {"type": "feat", "section": "Features"},
+        {"type": "fix", "section": "Bug Fixes"},
+        {"type": "deps", "section": "Dependencies"},
+        {"type": "chore", "section": "Miscellaneous", "hidden": false}
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Configure Dependabot to use conventional commit prefixes with custom scopes that distinguish between npm and GitHub Actions updates, and configure release-please to include all commit types in changelogs:

**Commit message formats:**
- **Production npm deps**: `deps(npm):` → triggers **PATCH** release
- **Dev npm deps**: `chore(npm):` → included in changelog, no release trigger
- **GitHub Actions**: `chore(actions):` → included in changelog, no release trigger

**Groups:**
- Major updates separated from minor/patch into different PRs for easier review

**Release-please changelog sections:**
- Features, Bug Fixes, Dependencies, Miscellaneous

## Key Features

✅ All production npm dependency updates trigger patch releases  
✅ Scopes distinguish npm deps from Actions  
✅ Prefixes distinguish prod from dev dependencies  
✅ Major updates grouped separately for review  
✅ All commit types appear in changelog

## Configuration Details

**Custom Scopes:**
Instead of using `include: "scope"` (which produces `deps(deps):`), we manually specify scopes in the prefix:
- `prefix: "deps(npm)"` for production npm
- `prefix-development: "chore(npm)"` for dev npm
- `prefix: "chore(actions)"` for GitHub Actions

**Groups:**
Major updates and minor/patch updates are separated into different PRs using `update-types`, making it easier to review breaking changes separately.

## How It Works

**Release-please version bumps:**
- `feat:` → MINOR version bump (1.x.0)
- `fix:` or `deps:` → PATCH version bump (1.0.x)
- `chore:` → no version bump (included in next release)

**Example commit messages:**
- `deps(npm): bump nan from 2.24.0 to 2.25.0` → triggers PATCH release
- `chore(npm): bump eslint from 8.0.0 to 9.0.0` → no release
- `chore(actions): bump actions/setup-node from 4 to 6` → no release

## Changes

**`.github/dependabot.yml`:**
- Configured `prefix: "deps(npm)"` for production npm dependencies
- Configured `prefix-development: "chore(npm)"` for dev npm dependencies
- Configured `prefix: "chore(actions)"` for GitHub Actions
- Added `groups` to separate major from minor/patch updates
- Increased `open-pull-requests-limit` to 10

**`release-please-config.json`:**
- Added `changelog-sections` to include feat, fix, deps, and chore commits
- Each type gets its own section with descriptive heading

## Effect on Existing PRs

Once merged:
- The two existing `chore(deps)` commits (#10, #11) will appear in the "Miscellaneous" section of the next release changelog
- Future production dependency updates will use `deps(npm):` prefix and trigger patch releases
- Dev dependencies and Actions will use `chore` prefix and appear in changelogs without triggering releases

## References

- [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference)
- [What does "include: scope" actually do?](https://github.com/dependabot/dependabot-core/issues/8443)
- [Grouped version updates by semantic version level](https://github.blog/changelog/2023-08-17-grouped-version-updates-by-semantic-version-level-for-dependabot/)
- [Release-please conventional commits](https://github.com/googleapis/release-please)

## Test Plan

- [x] Validate dependabot.yml syntax with `@bugron/validate-dependabot-yaml`
- [ ] Merge this PR
- [ ] Check that existing release PR (#13) gets updated to include the two `chore(deps)` commits in changelog
- [ ] Wait for next Dependabot PR for:
  - Production npm dependency → verify `deps(npm):` prefix
  - Dev npm dependency → verify `chore(npm):` prefix
  - GitHub Action → verify `chore(actions):` prefix
- [ ] Verify release-please updates the release PR with patch bump for production deps