### PR TITLE
feat(ci): add npm audit security check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,24 @@ jobs:
         run: |
           test -f dmx_native.node
           echo "Build successful on Node.js ${{ matrix.node-version }}"
+
+  security-audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: npm install --package-lock-only
+
+      - name: Run npm audit
+        run: npm audit --audit-level=moderate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,5 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - name: Install dependencies
-        run: npm install --package-lock-only
-
       - name: Run npm audit
         run: npm audit --audit-level=moderate


### PR DESCRIPTION
## Summary

Adds automated dependency vulnerability scanning to CI using npm audit.

## Changes

- New `security-audit` job in CI workflow
- Runs `npm audit --audit-level=moderate` to fail on moderate+ severity vulnerabilities
- Uses Node.js version from `.nvmrc` for consistency
- Lightweight check using `--package-lock-only` (no native build required)

## Benefits

- Catches vulnerable dependencies before merge
- Complements existing Dependabot configuration
- Zero additional dependencies or third-party services
- Fails fast on security issues